### PR TITLE
Sugestões

### DIFF
--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/TwitchHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/TwitchHandler.kt
@@ -1,19 +1,20 @@
 package dev.kotlinautas.twitch4k.components
 
-import dev.kotlinautas.twitch4k.entity.RoomState
+import dev.kotlinautas.twitch4k.components.handlers.MessageHandlerDiscovery
 import dev.kotlinautas.twitch4k.interfaces.Sender
 import dev.kotlinautas.twitch4k.util.IRCMessageUtil
 import org.slf4j.LoggerFactory
 import java.io.InputStream
+import java.security.Key
 
 class TwitchHandler(
     private val inputStream: InputStream,
-    private val channels: List<String>,
-    private val sender: Sender
+    channels: List<String>,
+    sender: Sender
 ) : Runnable {
 
     private val logger = LoggerFactory.getLogger("TWITCH_HANDLER")
-    private val roomStateMap: MutableMap<Int, RoomState> = mutableMapOf()
+    private val messageHandlerDiscovery = MessageHandlerDiscovery(channels, sender)
 
     override fun run() {
         val bufferedReader = inputStream.bufferedReader()
@@ -21,113 +22,9 @@ class TwitchHandler(
             val message = bufferedReader.readLine()
             if (message != null) {
                 val rawMessage = IRCMessageUtil.parseRawMessage(message)
-                //logger.info(rawMessage.toString())
-
-                when (rawMessage.command) {
-
-                    "001" -> {
-                        logger.info("Autenticado com sucesso!")
-
-                        // Registrando nas Twitch Capabilities
-                        sender.sendMessage(TwitchMessages.membershipCommands())
-                        sender.sendMessage(TwitchMessages.membershipCapability())
-                        sender.sendMessage(TwitchMessages.membershipTags())
-
-                        // Entrando nos canais
-                        channels.forEach { channel ->
-                            sender.sendMessage(TwitchMessages.joinMessage(channel))
-                        }
-                    }
-
-                    "002",
-                    "003",
-                    "004",
-                    "353",
-                    "366",
-                    "372",
-                    "375",
-                    "376" -> {
-                    }
-
-                    "CAP" -> {
-                        if (rawMessage.params.contains("ACK")) {
-                            when {
-                                rawMessage.params.last()
-                                    .contains("commands") -> logger.info("Recebido o ACK da Capability COMMANDS")
-
-                                rawMessage.params.last()
-                                    .contains("membership") -> logger.info("Recebido o ACK da Capability MEMBERSHIP")
-
-                                rawMessage.params.last()
-                                    .contains("tags") -> logger.info("Recebido o ACK da Capability TAGS")
-                            }
-
-                        }
-                    }
-
-                    "JOIN" -> {
-                        val chatter = IRCMessageUtil.getChatterUsernameFromPrefix(rawMessage.prefix)
-                        logger.info("$chatter entrou no canal ${rawMessage.params.first()}")
-                    }
-
-                    "PART" -> {
-                        val chatter = IRCMessageUtil.getChatterUsernameFromPrefix(rawMessage.prefix)
-                        logger.info("$chatter saiu no canal ${rawMessage.params.first()}")
-                    }
-
-                    "USERSTATE",
-                    "ROOMSTATE" -> {
-                        val channelId = rawMessage.tags["room-id"]?.toInt() ?: 0
-                        val channelName = rawMessage.params.first()
-
-                        val roomState = roomStateMap.getOrDefault(
-                            channelId,
-                            RoomState(
-                                channelId,
-                                channelName,
-                                rawMessage.tags.toMutableMap()))
-
-                        rawMessage.tags.forEach { (key, value) ->
-                            if(key != "room-id") roomState.tags[key] = value
-                        }
-
-                        roomStateMap[channelId] = roomState
-                        logger.info(roomState.toString())
-                    }
-
-                    "NOTICE" -> {
-                        when (rawMessage.tags["msg-id"]) {
-                            "emote_only_on" -> logger.info("O chat do canal ${rawMessage.params.first()} está no modo apenas emote")
-                            "emote_only_off" -> logger.info("O chat do canal ${rawMessage.params.first()} não está no modo apenas emote")
-                            "followers_on" -> logger.info("O chat do canal ${rawMessage.params.first()} está no modo apenas seguidores")
-                            "followers_off" -> logger.info("O chat do canal ${rawMessage.params.first()} não está no modo apenas seguidores")
-                            "slow_on" -> logger.info("O chat do canal ${rawMessage.params.first()} está no modo lento")
-                            "slow_off" -> logger.info("O chat do canal ${rawMessage.params.first()} não está no modo lento")
-                            "subs_on" -> logger.info("O chat do canal ${rawMessage.params.first()} está no modo apenas inscritos")
-                            "subs_off" -> logger.info("O chat do canal ${rawMessage.params.first()} não está no apenas inscritos")
-                        }
-                    }
-
-                    "PING" -> {
-                        logger.info("Mensagem de PING recebida, respondendo com um PONG")
-                        sender.sendMessage(TwitchMessages.pongMessage(rawMessage.params.first()))
-                    }
-
-                    "PRIVMSG" -> {
-                        logger.info(rawMessage.toString())
-                        val chatter = IRCMessageUtil.getChatterUsernameFromPrefix(rawMessage.prefix)
-                        val channel = rawMessage.params.first().removePrefix("#")
-                        val text = rawMessage.params.last().removePrefix(":")
-                        logger.info("[$channel] $chatter: $text")
-                        //TODO: Implementar um Observer aqui
-                    }
-
-                    else -> logger.error("Comando não esperado: ${rawMessage.command}")
-
-                }
-
+                val handler = messageHandlerDiscovery.handleMessageFor(rawMessage.command)
+                handler?.handle(rawMessage) ?: logger.error("Comando não esperado: ${rawMessage.command}")
             }
         }
     }
-
 }

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/AbstractMessageHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/AbstractMessageHandler.kt
@@ -1,0 +1,7 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import org.slf4j.LoggerFactory
+
+abstract class AbstractMessageHandler : MessageHandler {
+    val logger = LoggerFactory.getLogger("TWITCH_HANDLER")
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/AuthenticationHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/AuthenticationHandler.kt
@@ -1,0 +1,27 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import dev.kotlinautas.twitch4k.components.TwitchMessages
+import dev.kotlinautas.twitch4k.entity.RawMessage
+import dev.kotlinautas.twitch4k.interfaces.Sender
+
+class AuthenticationHandler(
+    private val channels: List<String>,
+    private val sender: Sender
+) : AbstractMessageHandler() {
+
+    override val codes: Array<String> = arrayOf("001")
+
+    override fun handle(rawMessage: RawMessage) {
+        logger.info("Autenticado com sucesso!")
+
+        // Registrando nas Twitch Capabilities
+        sender.sendMessage(TwitchMessages.membershipCommands())
+        sender.sendMessage(TwitchMessages.membershipCapability())
+        sender.sendMessage(TwitchMessages.membershipTags())
+
+        // Entrando nos canais
+        channels.forEach { channel ->
+            sender.sendMessage(TwitchMessages.joinMessage(channel))
+        }
+    }
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/CapabilityHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/CapabilityHandler.kt
@@ -1,0 +1,19 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import dev.kotlinautas.twitch4k.entity.RawMessage
+
+class CapabilityHandler : AbstractMessageHandler() {
+
+    override val codes: Array<String> = arrayOf("CAP")
+
+    override fun handle(rawMessage: RawMessage) {
+        if (rawMessage.params.contains("ACK")) {
+            val command = rawMessage.params.last()
+            when {
+                command.contains("commands") -> logger.info("Recebido o ACK da Capability COMMANDS")
+                command.contains("membership") -> logger.info("Recebido o ACK da Capability MEMBERSHIP")
+                command.contains("tags") -> logger.info("Recebido o ACK da Capability TAGS")
+            }
+        }
+    }
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/JoinHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/JoinHandler.kt
@@ -1,0 +1,13 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import dev.kotlinautas.twitch4k.entity.RawMessage
+import dev.kotlinautas.twitch4k.util.IRCMessageUtil
+
+class JoinHandler : AbstractMessageHandler() {
+    override val codes: Array<String> = arrayOf("JOIN")
+
+    override fun handle(rawMessage: RawMessage) {
+        val chatter = IRCMessageUtil.getChatterUsernameFromPrefix(rawMessage.prefix)
+        logger.info("$chatter entrou no canal ${rawMessage.params.first()}")
+    }
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/MessageHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/MessageHandler.kt
@@ -1,0 +1,8 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import dev.kotlinautas.twitch4k.entity.RawMessage
+
+interface MessageHandler {
+    val codes: Array<String>
+    fun handle(rawMessage: RawMessage)
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/MessageHandlerDiscovery.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/MessageHandlerDiscovery.kt
@@ -1,0 +1,23 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import dev.kotlinautas.twitch4k.interfaces.Sender
+
+class MessageHandlerDiscovery(
+    channels: List<String>,
+    sender: Sender
+) {
+
+    private val handlers = listOf(
+        AuthenticationHandler(channels, sender),
+        CapabilityHandler(),
+        JoinHandler(),
+        NoticeHandler(),
+        NotImplementedHandler(),
+        PartHandler(),
+        PingHandler(sender),
+        PrivateMessageHandler(),
+        StateHandler()
+    )
+
+    fun handleMessageFor(code: String) = handlers.find { it.codes.contains(code) }
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/NotImplementedHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/NotImplementedHandler.kt
@@ -1,0 +1,18 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import dev.kotlinautas.twitch4k.entity.RawMessage
+
+class NotImplementedHandler : AbstractMessageHandler() {
+    override val codes: Array<String> = arrayOf(
+        "002",
+        "003",
+        "004",
+        "353",
+        "366",
+        "372",
+        "375",
+        "376"
+    )
+
+    override fun handle(message: RawMessage) { }
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/NoticeHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/NoticeHandler.kt
@@ -1,0 +1,21 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import dev.kotlinautas.twitch4k.entity.RawMessage
+
+class NoticeHandler : AbstractMessageHandler() {
+
+    override val codes: Array<String> = arrayOf("NOTICE")
+
+    override fun handle(rawMessage: RawMessage) {
+        when (rawMessage.tags["msg-id"]) {
+            "emote_only_on" -> logger.info("O chat do canal ${rawMessage.params.first()} está no modo apenas emote")
+            "emote_only_off" -> logger.info("O chat do canal ${rawMessage.params.first()} não está no modo apenas emote")
+            "followers_on" -> logger.info("O chat do canal ${rawMessage.params.first()} está no modo apenas seguidores")
+            "followers_off" -> logger.info("O chat do canal ${rawMessage.params.first()} não está no modo apenas seguidores")
+            "slow_on" -> logger.info("O chat do canal ${rawMessage.params.first()} está no modo lento")
+            "slow_off" -> logger.info("O chat do canal ${rawMessage.params.first()} não está no modo lento")
+            "subs_on" -> logger.info("O chat do canal ${rawMessage.params.first()} está no modo apenas inscritos")
+            "subs_off" -> logger.info("O chat do canal ${rawMessage.params.first()} não está no apenas inscritos")
+        }
+    }
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/PartHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/PartHandler.kt
@@ -1,0 +1,14 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import dev.kotlinautas.twitch4k.entity.RawMessage
+import dev.kotlinautas.twitch4k.util.IRCMessageUtil
+import org.slf4j.LoggerFactory
+
+class PartHandler : AbstractMessageHandler() {
+    override val codes: Array<String> = arrayOf("PART")
+
+    override fun handle(rawMessage: RawMessage) {
+        val chatter = IRCMessageUtil.getChatterUsernameFromPrefix(rawMessage.prefix)
+        logger.info("$chatter saiu no canal ${rawMessage.params.first()}")
+    }
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/PingHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/PingHandler.kt
@@ -1,0 +1,17 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import dev.kotlinautas.twitch4k.components.TwitchMessages
+import dev.kotlinautas.twitch4k.entity.RawMessage
+import dev.kotlinautas.twitch4k.interfaces.Sender
+
+class PingHandler(
+    private val sender: Sender,
+) : AbstractMessageHandler() {
+
+    override val codes: Array<String> = arrayOf("PING")
+
+    override fun handle(rawMessage: RawMessage) {
+        logger.info("Mensagem de PING recebida, respondendo com um PONG")
+        sender.sendMessage(TwitchMessages.pongMessage(rawMessage.params.first()))
+    }
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/PrivateMessageHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/PrivateMessageHandler.kt
@@ -1,0 +1,17 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import dev.kotlinautas.twitch4k.entity.RawMessage
+import dev.kotlinautas.twitch4k.util.IRCMessageUtil
+
+class PrivateMessageHandler : AbstractMessageHandler() {
+    override val codes: Array<String> = arrayOf("PRIVMSG")
+
+    override fun handle(rawMessage: RawMessage) {
+        logger.info(rawMessage.toString())
+        val chatter = IRCMessageUtil.getChatterUsernameFromPrefix(rawMessage.prefix)
+        val channel = rawMessage.params.first().removePrefix("#")
+        val text = rawMessage.params.last().removePrefix(":")
+        logger.info("[$channel] $chatter: $text")
+        //TODO: Implementar um Observer aqui
+    }
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/StateHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/StateHandler.kt
@@ -1,0 +1,31 @@
+package dev.kotlinautas.twitch4k.components.handlers
+
+import dev.kotlinautas.twitch4k.entity.RawMessage
+import dev.kotlinautas.twitch4k.entity.RoomState
+
+class StateHandler : AbstractMessageHandler() {
+
+    private val roomStateMap: MutableMap<Int, RoomState> = mutableMapOf()
+
+    override val codes: Array<String> = arrayOf("USERSTATE", "ROOTSTATE")
+
+    override fun handle(rawMessage: RawMessage) {
+        val channelId = rawMessage.tags["room-id"]?.toInt() ?: 0
+        val channelName = rawMessage.params.first()
+
+        val roomState = roomStateMap.getOrDefault(
+            channelId,
+            RoomState(
+                channelId,
+                channelName,
+                rawMessage.tags.toMutableMap())
+        )
+
+        rawMessage.tags.forEach { (key, value) ->
+            if(key != "room-id") roomState.tags[key] = value
+        }
+
+        roomStateMap[channelId] = roomState
+        logger.info(roomState.toString())
+    }
+}

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/StateHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/StateHandler.kt
@@ -7,7 +7,7 @@ class StateHandler : AbstractMessageHandler() {
 
     private val roomStateMap: MutableMap<Int, RoomState> = mutableMapOf()
 
-    override val codes: Array<String> = arrayOf("USERSTATE", "ROOTSTATE")
+    override val codes: Array<String> = arrayOf("USERSTATE", "ROOMSTATE")
 
     override fun handle(rawMessage: RawMessage) {
         val channelId = rawMessage.tags["room-id"]?.toInt() ?: 0

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/entity/RawMessage.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/entity/RawMessage.kt
@@ -30,19 +30,12 @@ class RawMessage private constructor(
         var command: String? = null
         val params: MutableList<String> = mutableListOf()
 
-//        fun setRaw(rawMessage: String) = apply { this.raw = rawMessage }
-//        fun addTag(key: String, value: String) = apply { this.tags[key] = value }
-//        fun setPrefix(prefix: String) = apply { this.prefix = prefix }
-//        fun setCommand(command: String) = apply { this.command = command }
-//        fun addParam(param: String) = apply { this.params.add(param) }
-        fun build(): RawMessage {
-
-            if (raw == null) throw NullPointerException("A propriedade raw não pode ser nula")
-            if (command == null) throw NullPointerException("A propriedade prefix não pode ser nula")
-
-            return RawMessage(raw!!, tags.toMap(), prefix, command!!, params)
-
-        }
+        fun build() = RawMessage(
+            raw = this.raw ?: throw NullPointerException("A propriedade raw não pode ser nula"),
+            command = this.command ?: throw NullPointerException("A propriedade command não pode ser nula"),
+            tags = this.tags.toMap(),
+            prefix = this.prefix,
+            params = this.params.toList()
+        )
     }
-
 }

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/entity/RoomState.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/entity/RoomState.kt
@@ -8,7 +8,7 @@ data class RoomState(
 
     val isEmoteOnlyMode get() = tags["emote-only"] != "0"
 
-    val isFollowersOnlyMode get() = tags["followers-only"] != "0" && tags["followers-only"] != "-1"
+    val isFollowersOnlyMode get() = (tags["followers-only"]?.toIntOrNull() ?: -1) > 0
 
     val isSlowMode get() = tags["slow"] != "0"
 
@@ -17,10 +17,12 @@ data class RoomState(
     override fun toString(): String {
         return """
         Estado do canal $channelName ($channelId)
-        Modo apenas emote: ${if (isEmoteOnlyMode) "Ativado" else "Desativado"}
-        Modo apenas seguidores: ${if (isFollowersOnlyMode) "Ativado" else "Desativado"}
-        Modo lento: ${if (isSlowMode) "Ativado" else "Desativado"}
-        Modo apenas inscritos: ${if (isSubsOnlyMode) "Ativado" else "Desativado"}
+        Modo apenas emote: ${isEmoteOnlyMode.toHumanReadable()}
+        Modo apenas seguidores: ${isFollowersOnlyMode.toHumanReadable()}
+        Modo lento: ${isSlowMode.toHumanReadable()}
+        Modo apenas inscritos: ${isSubsOnlyMode.toHumanReadable()}
         """.trimIndent()
     }
+
+    private fun Boolean.toHumanReadable() = if (this) "Ativado" else "Desativado"
 }


### PR DESCRIPTION
> A ideia neste PR é apenas dar sugestões de implementações:

## TwitchHandler
Como são muitos os códigos que determinam o tipo de mensagem a ser tratada, deixar esta lógica dentro do TwitchHandler pode deixar esta classe muito extensa a longo prazo, visto que as comunicações ainda estão em desenvolvimento.

Uma ideia é criar algo similar a um "service discovery" ou "strategy pattern", é ondeo `MessageHandler` entra:

## MessageHandler
Criei a interface MessageHandler que contém o "identificador" de cada handler (neste caso pode ser vários, caso um identificador pode ter muito a ver com outro, usei desta forma devido aos comandos numéricos 
```
 "002", "003", "004", "353", "366", "372", "375", "376"
```

e também pelos comandos "USERSTATE" e "ROOMSTATE" que já estavam agrupados

## AbstractMessageHandler
Criei este abstract pois notei que todos os handlers utilizam o mesmo logger com o mesmo ID, porém, pode-se remover este cara e criar um logger pra cada handler (seria mais facil pra identificar onde está o erro/info talvez)

## MessageHandlerDiscovery
Cada Handler precisa implementar o "code" para o discovery conseguir identificar o handler 
E o método `handle` que será usado para executar o comando com o `RawMessage`

Dentro do discovery foi criada a instancia de TODOS os handlers e adicionado a uma lista, é essa lista que o discovery percorrerá buscando pelo "code" enviado pela Twitch e identificará como executar a mensagem `RawMessage`

## RawMessage - Builder
Neste caso apenas usei a validação de NullPointer direto na criação do objeto, isto fará o mesmo que validar se o `raw` e `command` é nulo com if como estava anteriormente

```kotlin
RawMessage(
 raw = this.raw ?: throw NullPointerException("A propriedade raw não pode ser nula"),
 command = this.command ?: throw NullPointerException("A propriedade command não pode ser nula"),
 ...
)
```

## RoomState
Foi criado uma _extension function_ do Boolean pra transformar o bool em texto lido por humanos
`Boolean.toHumanReadable`: reduzindo duplicação de código (mesmo if pra vários lugares)

E no `isFollowersOnlyMode`, fiz a conversão pra `IntOrNull`, uma forma talvez mais segura de validar se é followersOnly devido a flexibilidade do valor ser -1, 0, etc... "vai que vem um -2 aí, e nào ta tratado, ficaria como ativado"

Ainda sobre este cara, a lista de roomState está sendo criado direto no Handler de USERSTATE e ROOMSTATE, mas, se posteriormente esta lista for utilizada em outros comandos, talvez seja necessário voltar ele pro TwitchHandler e repassá-lo para os handlers necessários seja por construtor (navegando pelo discovery) ou por setter