### PR TITLE
Mais algumas organizações

### DIFF
--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/TwitchSender.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/TwitchSender.kt
@@ -4,6 +4,9 @@ import org.slf4j.LoggerFactory
 import java.io.OutputStream
 import java.util.Queue
 
+/**
+* Handler responsável por enviar as mensagens para Twitch
+* */
 class TwitchSender(
     private val outputStream: OutputStream,
     private val queue: Queue<String>

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/MessageHandlerDiscovery.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/MessageHandlerDiscovery.kt
@@ -7,15 +7,14 @@ class MessageHandlerDiscovery() {
 
     var onReceivedChatMessageListener: OnReceivedChatMessageListener? = null
 
-
     fun handleMessageFor(message: RawMessage): MessageHandler? {
         return when (message.command) {
-            in arrayOf("CAP") -> CapabilityHandler()
-            in arrayOf("JOIN") -> JoinHandler()
-            in arrayOf("NOTICE") -> NoticeHandler()
-            in arrayOf("PART") -> PartHandler()
-            in arrayOf("PING") -> PingHandler()
-            in arrayOf("PRIVMSG") -> PrivateMessageHandler(onReceivedChatMessageListener)
+            "CAP" -> CapabilityHandler()
+            "JOIN" -> JoinHandler()
+            "NOTICE" -> NoticeHandler()
+            "PART" -> PartHandler()
+            "PING" -> PingHandler()
+            "PRIVMSG" -> PrivateMessageHandler(onReceivedChatMessageListener)
             in arrayOf("USERSTATE", "ROOMSTATE") -> StateHandler()
             in arrayOf(
                 "002",

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/PrivateMessageHandler.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/components/handlers/PrivateMessageHandler.kt
@@ -15,8 +15,9 @@ class PrivateMessageHandler(private val listener: OnReceivedChatMessageListener?
         val text = rawMessage.params.last().removePrefix(":")
         logger.info("[$channel] $chatter: $text")
 
-        val chat = Chat(sender)
-        listener?.onReceived(rawMessage.toChatMessage(), chat)
+        val message = rawMessage.toChatMessage()
+        val chat = Chat(message.channel, sender)
+        listener?.onReceived(message, chat)
     }
 
 }

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/entity/Chat.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/entity/Chat.kt
@@ -3,9 +3,9 @@ package dev.kotlinautas.twitch4k.entity
 import dev.kotlinautas.twitch4k.components.TwitchMessages
 import dev.kotlinautas.twitch4k.interfaces.Sender
 
-class Chat (private val sender: Sender) {
+class Chat (private val channel: String, private val sender: Sender) {
 
-    fun send(channel:String, message:String){
+    fun send(message:String){
         sender.sendMessage(TwitchMessages.privMessage(channel, message))
     }
 

--- a/lib/src/main/kotlin/dev/kotlinautas/twitch4k/interfaces/OnReceivedChatMessageListener.kt
+++ b/lib/src/main/kotlin/dev/kotlinautas/twitch4k/interfaces/OnReceivedChatMessageListener.kt
@@ -3,7 +3,7 @@ package dev.kotlinautas.twitch4k.interfaces
 import dev.kotlinautas.twitch4k.entity.Chat
 import dev.kotlinautas.twitch4k.entity.ChatMessage
 
-interface OnReceivedChatMessageListener : EventListener {
+fun interface OnReceivedChatMessageListener : EventListener {
 
     fun onReceived(message: ChatMessage, chat: Chat)
 


### PR DESCRIPTION
## Twitch4k
Apenas algumas separações de código em métodos, isolando algumas responsabilidades como a criação do socket e das threads dos handlers

Também utilizado o método `.also` do kotlin, funciona igual o `.apply` porém sem a troca do contexto **this**, ou seja, o código dentro do bloco { }, tem referencia ao próprio objeto porém com "it", exemplo dos 2 usos no método da criação do socket...
 
```kotlin
// com o `apply`, dentro do bloco { }, o "this" é a referencia do próprio objeto (socket)
Socket().apply {  
   receiveBufferSize = 4096
}

// com o `also`, dentro do bloco { }, o "this" é a referência da classe que está executando o código (no caso o Twitch4k)
socket.also { 
   it.connect( ... )
}
```

## TwitchHandler
Mesma alteração com relação ao uso do `.also` (e um toque pessoal usando `when` ao invés do `if else`)
Um ponto diferenciado do `.also` com relação ao `.apply` é a possibilidade de "nomear" a referencia

```kotlin
// Sem nomear a referencia
MessageHandlerDiscovery().also {  it.onReceivedChatMessageListener = onReceivedChatMessageListener } 

// Nomeando a referencia
MessageHandlerDiscovery().also { discovery -> 
    discovery.onReceivedChatMessageListener = onReceivedChatMessageListener 
} 
```

## MessageHandlerDiscovery
Apenas remoção do `in ArrayOf(...)` para os casos em que se testa apenas 1 string

## Chat
Neste caso, como já temos de qual `channel` que veio a mensagem, já estou passando direto para o Chat, assim quem for implementar o bot **não** precisará passar o `channel` para o `send(message: String)`

Ficando a chamada ao chat desta maneira
```kotlin
chat.send("Hello World")
```

Sem a necessidade de fazer isto
```kotlin
chat.send(message.channel, "Hello World")
```

### **A não ser que você queira deixar aberto ao criador do BOT definir pra qual dos canais cadastrados ele queira mandar a mensagem, mesmo "divergindo" da origem**

## PrivateMessageHandler
Neste foi implementado a solução para o Chat descrito acima

## OnReceivedChatMessageListener
Transformando a interface em uma `Functional Interface`
Assim como no java tem a anotação `@FunctionalInterface` para as interfaces, no Kotlin tem a `fun interface`, o que isto quer dizer?

Garante que a interface terá **apenas um método a ser implementado (abstrato)** e isto permite a implementação da interface com **lambda** (sem a necessidade de criar uma classe para implementar o método, mas também não tira essa possibilidade)

Exemplo de mudança:
**Antes**
```kotlin
    class BotMessageListener : OnReceivedChatMessageListener { 
    
        fun onReceived(message: ChatMessage, chat: Chat) { 
            if (message.text.startsWith("test")) {
                chat.send("Hello World")
            }
        }
        
    }
   
    fun main() {
        val t4k = Twitch4K(...)
        t4k.setOnReceivedChatMessageListener(BotMessageListener())
        t4k.start()
    }
```

**Depois**
```kotlin
    fun main() {
        val t4k = Twitch4K(...)
    
        t4k.setOnReceivedChatMessageListener { message, chat ->
            if (message.text.startsWith("test")) {
                chat.send("Hello World")
            }
        }

        t4k.start()
    }
```


